### PR TITLE
fix(db): sélectionner par défaut la base 'nutritrack' pour éviter 'No…

### DIFF
--- a/base-de-donnees/connexion.js
+++ b/base-de-donnees/connexion.js
@@ -6,7 +6,7 @@ const configDB = {
     host: process.env.DB_HOST || 'localhost',
     user: process.env.DB_USER || 'root',
     password: process.env.DB_PASSWORD || '',
-    database: process.env.DB_NAME || '',
+    database: process.env.DB_NAME || 'nutritrack',
     waitForConnections: true,
     connectionLimit: 10,
     queueLimit: 0


### PR DESCRIPTION
… database selected'